### PR TITLE
feat: add timeout to Agent.generate_response()

### DIFF
--- a/rooms/agent.py
+++ b/rooms/agent.py
@@ -80,11 +80,15 @@ class Agent:
             if self.config.max_tokens:
                 litellm_params["max_tokens"] = self.config.max_tokens
                 
+            litellm_params["timeout"] = self.config.timeout
             litellm_params.update(params)
 
             response = litellm.completion(**litellm_params)
             return response.choices[0].message.content.strip()
             
+        except litellm.Timeout as e:
+            logger.error(f"Timeout logic executed for agent '{self.name}' on model '{self.model}': {e}")
+            return f"[Timeout Error: The model '{self.model}' took too long to respond ({self.config.timeout}s)]"
         except Exception as e:
             logger.error(f"Error getting response from agent '{self.name}' on model '{self.model}': {e}")
             return f"[Error: Could not generate response. Details: {str(e)}]"

--- a/rooms/config.py
+++ b/rooms/config.py
@@ -19,6 +19,7 @@ class AgentConfig(BaseModel):
     model: str = Field(default="ollama/llama3", description="LiteLLM compatible model name or placeholder for custom")
     temperature: float = Field(default=0.7, description="Generation temperature")
     max_tokens: Optional[int] = Field(default=None, description="Max generated tokens")
+    timeout: int = Field(default=30, description="Timeout in seconds for model generation")
     color: str = Field(default="blue", description="CLI output color for this agent")
     custom_function_path: Optional[str] = Field(default=None, description="Path to .py file if model_type is custom_function")
     custom_function_name: Optional[str] = Field(default=None, description="Name of the python function to call")


### PR DESCRIPTION
Closes #1

Closes #1

### Description
This PR prevents sessions from hanging indefinitely when an external API or local model node (like Ollama) becomes completely unresponsive.

### Changes Made
- Added a `timeout: int = Field(default=30)` setting to [AgentConfig](cci:2://file:///e:/ARPA/OpenSource/Rooms/rooms/config.py:13:0-25:113) in [rooms/config.py](cci:7://file:///e:/ARPA/OpenSource/Rooms/rooms/config.py:0:0-0:0).
- Updated the `litellm.completion()` call in [rooms/agent.py](cci:7://file:///e:/ARPA/OpenSource/Rooms/rooms/agent.py:0:0-0:0) to utilize this timeout config rule.
- Added explicit `try/except` handling for `litellm.Timeout` to gracefully log the error and permit the session to proceed instead of permanently freezing the interaction.

### Verification
All internal tests pass successfully with these changes.
