### PR TITLE
Respect disabled shipped personas

### DIFF
--- a/rooms/settings.py
+++ b/rooms/settings.py
@@ -196,7 +196,7 @@ def get_default_personas(settings: RoomsSettings) -> List[AgentConfig]:
         return [persona_settings_to_agent_config(p, settings.defaults) for p in settings.personas]
     if settings.use_shipped_personas:
         return _shipped_persona_dicts_to_configs(settings.defaults)
-    return _shipped_persona_dicts_to_configs(settings.defaults)
+    return []
 
 
 def resolve_preset_model(settings: RoomsSettings, preset_name: str) -> str:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -57,6 +57,12 @@ def test_shipped_personas_use_defaults_model():
     assert personas[0].name == "Elena (The Lawyer)"
 
 
+def test_empty_personas_respects_disabled_shipped_personas():
+    settings = RoomsSettings(use_shipped_personas=False)
+    personas = get_default_personas(settings)
+    assert personas == []
+
+
 def test_custom_personas_from_yaml():
     settings = RoomsSettings(
         use_shipped_personas=False,


### PR DESCRIPTION
## Summary
- Return an empty persona list when `use_shipped_personas` is disabled and no custom personas are configured.
- Add a settings unit test for the empty-persona case from the issue.

Fixes #31

## Verification
- uv run --with pytest --with pydantic --with pyyaml pytest tests/test_settings.py -q
- uv run --with pytest --with pydantic --with pyyaml --with litellm --with rich --with prompt_toolkit pytest tests/ -q
- uv run --with flake8 flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics