### PR TITLE
[codex] Fix disabled shipped personas fallback

### DIFF
--- a/rooms/settings.py
+++ b/rooms/settings.py
@@ -196,7 +196,7 @@ def get_default_personas(settings: RoomsSettings) -> List[AgentConfig]:
         return [persona_settings_to_agent_config(p, settings.defaults) for p in settings.personas]
     if settings.use_shipped_personas:
         return _shipped_persona_dicts_to_configs(settings.defaults)
-    return _shipped_persona_dicts_to_configs(settings.defaults)
+    return []
 
 
 def resolve_preset_model(settings: RoomsSettings, preset_name: str) -> str:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,10 +1,6 @@
-import os
-from pathlib import Path
-
 import pytest
 import yaml
 
-from rooms.config import AgentConfig
 from rooms.settings import (
     RoomsSettings,
     SettingsError,
@@ -55,6 +51,18 @@ def test_shipped_personas_use_defaults_model():
     assert len(personas) == len(SHIPPED_PERSONAS)
     assert all(p.model == "ollama/custom:7b" for p in personas)
     assert personas[0].name == "Elena (The Lawyer)"
+
+
+def test_disable_shipped_personas_with_empty_personas_returns_empty_list():
+    settings = RoomsSettings(use_shipped_personas=False, personas=[])
+    assert get_default_personas(settings) == []
+
+
+def test_disable_shipped_personas_without_personas_key_loads_empty_list(tmp_path):
+    cfg = tmp_path / "rooms.settings.yaml"
+    cfg.write_text("use_shipped_personas: false\n", encoding="utf-8")
+    settings = load_settings(str(cfg))
+    assert get_default_personas(settings) == []
 
 
 def test_custom_personas_from_yaml():


### PR DESCRIPTION
## Summary

- Respect `use_shipped_personas: false` when no YAML personas are configured.
- Add regression coverage for both an explicit empty personas list and a settings file without a `personas` key.
- Remove unused imports from the touched settings test module.

Closes #31.

## Validation

- `PYTHONPATH=. venv/bin/python -m pytest tests/test_settings.py -q`
- `PYTHONPATH=. venv/bin/python -m pytest tests/test_settings.py tests/test_cli_settings_smoke.py tests/test_cli.py -q`
- `PYTHONPATH=. venv/bin/python -m pytest tests/ -q`
- `venv/bin/python -m flake8 rooms/settings.py tests/test_settings.py --count --select=E9,F63,F7,F82 --show-source --statistics`
- `venv/bin/python -m flake8 rooms/settings.py tests/test_settings.py --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics`
