### PR TITLE
docs: add initial CHANGELOG.md using Keep a Changelog standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,13 @@
-\# Changelog
+# Changelog
 
 All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+> **Note:** This project is currently in a pre-release stage. Official versioned release entries will begin tracking here soon.
 
+## [Unreleased]
 
-> \*\*Note:\*\* This project is currently in a pre-release stage. Official versioned release entries will begin tracking here soon.
+### Added
 
-
-
-\## \[Unreleased]
-
-\### Added
-
-\- Created initial CHANGELOG.md structure following the Keep a Changelog standard.
-
+- Created initial CHANGELOG.md structure following the Keep a Changelog standard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
-# Changelog
+\# Changelog
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
-## [Unreleased]
 
-### Added
-- Created initial CHANGELOG.md structure following the Keep a Changelog standard.
+
+> \*\*Note:\*\* This project is currently in a pre-release stage. Official versioned release entries will begin tracking here soon.
+
+
+
+\## \[Unreleased]
+
+\### Added
+
+\- Created initial CHANGELOG.md structure following the Keep a Changelog standard.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Created initial CHANGELOG.md structure following the Keep a Changelog standard.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Use the Feature Request template. Explain the motivation behind the suggestion a
    ```
 4. **Add Tests**: If you are adding new logic, please include corresponding tests in `tests/test_session.py`.
 5. **Submit PR**: Provide a clear description of what the PR changes and why.
-
+6. **Update Changelog**: Please note that a project changelog exists at `CHANGELOG.md`. Contributors will be requested to update the `[Unreleased]` section of the changelog once official versioned releases begin.
 ---
 
 ## Design Philosophy

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ For deeper insights into how to leverage and modify the framework, please refer 
 - [Use Cases, Examples & Best Practices](docs/EXAMPLES.md) - Parameter cheat sheet, deep persona guide, scenario walkthroughs, and an edge case reference table.
 - [Testing Strategy](docs/TESTING.md) - How to write and run deterministic tests for multi-agent logic.
 - [Contributing Guide](CONTRIBUTING.md) - Learn how to contribute to the project, report bugs, and follow our design philosophy.
+- [Project Changelog](CHANGELOG.md) - Track all notable updates, fixes, and pre-release changes to the framework.
 
 ## Project Structure
 


### PR DESCRIPTION
Closes #10. Added a baseline CHANGELOG.md file to the repository root adhering to the Keep a Changelog standard.