### PR TITLE
chore: split heavy ML stack into optional mmory extras

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,10 @@ Rooms/
 ├── tests/              # Unit Tests
 │   └── test_session.py # Logic Verification
 ├── outputs/            # Session Transcripts
-├── cli.py                      # Interactive Wizard Entry Point
+├── cli.py                      # Interactive Wizard Entry Point      
 ├── rooms.settings.example.yaml # Settings template (commit this)
-├── requirements.txt            # Project Dependencies
+├── requirements.txt            # Core Project Dependencies
+└── requirements-memory.txt     # Optional Vector Memory Dependencies    # Project Dependencies
 ```
 
 `rooms.settings.yaml` is gitignored — create it locally with `python cli.py config init` or by copying the example file.
@@ -93,9 +94,14 @@ cd Rooms
 python -m venv venv
 venv\Scripts\activate  # Windows: venv\Scripts\activate | Unix: source venv/bin/activate
 
-# Install Dependencies
+# Install Core Dependencies
 pip install -r requirements.txt
 ```
+#### Optional: Long-Term Memory & RAG Support
+If you plan to use vector memory features (such as long-term agent memory across sessions), you will need to install the heavier machine learning dependencies separately:
+
+```bash
+pip install -r requirements-memory.txt
 
 ### 2. Configure defaults (optional)
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ pip install -r requirements.txt
 If you plan to use vector memory features (such as long-term agent memory across sessions (#13)), you will need to install the heavier machine learning dependencies separately:
 ```bash
 pip install -r requirements-memory.txt
+```
 
 ### 2. Configure defaults (optional)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Rooms/
 ├── cli.py                      # Interactive Wizard Entry Point      
 ├── rooms.settings.example.yaml # Settings template (commit this)
 ├── requirements.txt            # Core Project Dependencies
-└── requirements-memory.txt     # Optional Vector Memory Dependencies    # Project Dependencies
+└── requirements-memory.txt     # Optional Vector Memory Dependencies
 ```
 
 `rooms.settings.yaml` is gitignored — create it locally with `python cli.py config init` or by copying the example file.
@@ -98,8 +98,7 @@ venv\Scripts\activate  # Windows: venv\Scripts\activate | Unix: source venv/bin/
 pip install -r requirements.txt
 ```
 #### Optional: Long-Term Memory & RAG Support
-If you plan to use vector memory features (such as long-term agent memory across sessions), you will need to install the heavier machine learning dependencies separately:
-
+If you plan to use vector memory features (such as long-term agent memory across sessions (#13)), you will need to install the heavier machine learning dependencies separately:
 ```bash
 pip install -r requirements-memory.txt
 

--- a/requirements-memory.txt
+++ b/requirements-memory.txt
@@ -1,0 +1,3 @@
+chromadb>=0.4.0
+sentence-transformers>=2.2.2
+torch>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 litellm>=1.20.0
-chromadb>=0.4.0
-sentence-transformers>=2.2.2
-torch>=2.0.0
 rich>=13.0.0
 pydantic>=2.0.0
 prompt_toolkit>=3.0.0


### PR DESCRIPTION
Closes #35 

This PR separates the heavy machine learning packages (`chromadb`, `sentence-transformers`, `torch`) out of the main `requirements.txt` file and moves them into a new `requirements-memory.txt` file. 

This ensures that the core CLI installation remains lightweight and fast for new users and CI environments while preserving an explicit installation path for future vector memory features.