### PR TITLE
feat: add universal .env bootstrap and include skillware in requirements

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env in the project root (gitignored).
+# LiteLLM reads provider keys from process environment — not from rooms.settings.yaml.
+
+# DeepSeek (when defaults.litellm_model uses deepseek/...)
+DEEPSEEK_API_KEY=your-deepseek-api-key-here
+
+# OpenAI (optional)
+# OPENAI_API_KEY=your-openai-api-key-here
+
+# Anthropic (optional)
+# ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ You do **not** need a settings file to run the CLI — built-in defaults apply (
 |------|---------|---------|
 | `rooms.settings.example.yaml` | Yes (template) | Committed reference; copy or use `config init` |
 | `rooms.settings.yaml` | No (gitignored) | Your local overrides (model tag, user name, personas) |
+| `.env` | No (gitignored) | API keys and secrets for cloud LiteLLM providers |
 
 ```bash
 python cli.py config init    # copies example → rooms.settings.yaml in cwd
@@ -121,6 +122,15 @@ python cli.py config init    # copies example → rooms.settings.yaml in cwd
 # Edit rooms.settings.yaml — e.g. defaults.litellm_model from `ollama list`
 python cli.py config reset   # remove user file; revert to shipped defaults
 python cli.py --config path/to/settings.yaml
+```
+
+**API keys (cloud models only)**
+
+LiteLLM reads provider credentials from the process environment (not from YAML). For local development, copy `.env.example` to `.env` and set keys such as `DEEPSEEK_API_KEY` or `OPENAI_API_KEY`. Rooms loads `.env` automatically at startup (shell/CI env vars take precedence).
+
+```bash
+copy .env.example .env   # Windows
+# edit .env with your provider key(s)
 ```
 
 ### 3. Usage

--- a/cli.py
+++ b/cli.py
@@ -14,6 +14,7 @@ from rooms.agent import Agent
 from rooms.session import Session
 from rooms.storage import save_transcript
 from rooms.skills_cli import list_skills, inspect_skill, suggest_skills
+from rooms.env import bootstrap_environment
 from rooms.settings import (
     RoomsSettings,
     SettingsError,
@@ -436,6 +437,7 @@ def check_ollama_preflight(settings) -> bool:
     return ollama_preflight.run_ollama_preflight(settings)
 
 def main(argv: Optional[List[str]] = None) -> int:
+    bootstrap_environment()
     parser = build_parser()
     args = parser.parse_args(argv)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -25,6 +25,26 @@ Default model strings, timeouts, user profile, and optional persona overrides ar
 
 Search order: `--config path` → `./rooms.settings.yaml` → user config dir (`~/.config/rooms/settings.yaml` or `%APPDATA%\rooms\settings.yaml` on Windows).
 
+## Environment variables and `.env`
+
+Rooms separates **configuration** from **credentials**:
+
+| Source | Use for |
+|---|---|
+| `rooms.settings.yaml` | Models, personas, skills, timeouts, user defaults |
+| Process environment | Provider API keys (`DEEPSEEK_API_KEY`, `OPENAI_API_KEY`, etc.) |
+| `.env` (optional) | Local dev convenience; loaded into process env at startup |
+
+LiteLLM routes inference requests and reads provider keys from `os.environ`. LiteLLM does **not** parse `.env` files itself. Rooms bootstraps environment via `rooms.env.bootstrap_environment()` when the CLI starts and when settings are loaded.
+
+Precedence:
+
+1. Existing shell/CI environment variables (highest)
+2. `.env` in current working directory
+3. `.env` in repository root
+
+Never store API keys in `rooms.settings.yaml`.
+
 ## Session Memory & Timestamps
 All conversation history is held in RAM for the duration of the session. Each entry — agent turn, user message, and system introduction — is tagged with a `timestamp` (format: `YYYY-MM-DD HH:MM:SS`). This makes transcripts auditable without any external database.
 

--- a/docs/SKILLWARE.md
+++ b/docs/SKILLWARE.md
@@ -9,13 +9,15 @@ Rooms supports optional Skillware-based tool use for agents.
 - Agent replies remain human-readable even when tools are used.
 - Skill execution metadata is logged as structured session events.
 
-## Install (Optional)
+## Install
+
+Skillware is included in `requirements.txt` and installed with the core package:
 
 ```bash
-pip install skillware
+pip install -r requirements.txt
 ```
 
-Rooms works normally without Skillware. Skill commands and wizard steps fail gracefully with guidance.
+Skill manifests are still loaded lazily only when an agent has configured skills.
 
 ## Skills CLI Commands
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -38,6 +38,7 @@ $env:PYTHONPATH="."; python -m pytest tests/test_settings.py tests/test_cli_sett
 | `tests/test_cli_settings_smoke.py` | `cli.py config init`, `config reset`, `--config` wiring |
 | `tests/test_cli.py` | Wizard env cleanup, Skills CLI command behavior, wizard skill assignment flow |
 | `tests/test_skills_cli.py` | Skillware wrapper discovery/inspect normalization and suggestion matching |
+| `tests/test_env.py` | `.env` bootstrap precedence and settings integration |
 
 ## Session logic coverage
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ rich>=13.0.0
 pydantic>=2.0.0
 prompt_toolkit>=3.0.0
 pyyaml>=6.0.0
+python-dotenv>=1.0.0
+skillware

--- a/rooms.settings.example.yaml
+++ b/rooms.settings.example.yaml
@@ -1,5 +1,5 @@
 # Copy to rooms.settings.yaml (gitignored) or run: python cli.py config init
-# See: https://github.com/ARPAHLS/rooms/issues/26 and #27
+# API keys belong in .env (see .env.example), not in this file.
 
 defaults:
   litellm_model: "ollama/gemma4:e2b"

--- a/rooms/env.py
+++ b/rooms/env.py
@@ -1,0 +1,53 @@
+"""Process environment bootstrap for Rooms."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+_BOOTSTRAPPED = False
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def dotenv_search_paths() -> List[Path]:
+    """Return candidate .env paths, highest priority first."""
+    seen: set[Path] = set()
+    paths: List[Path] = []
+    for root in (Path.cwd(), repo_root()):
+        candidate = (root / ".env").resolve()
+        if candidate not in seen:
+            seen.add(candidate)
+            paths.append(candidate)
+    return paths
+
+
+def bootstrap_environment(*, force: bool = False) -> List[Path]:
+    """
+    Load optional .env file into process environment.
+
+    - Prefers `./.env` in the current working directory, then repository root.
+    - Uses override=False so real shell/CI environment variables always win.
+    - Safe to call multiple times.
+    """
+    global _BOOTSTRAPPED
+    if _BOOTSTRAPPED and not force:
+        return []
+
+    try:
+        from dotenv import load_dotenv
+    except ImportError:
+        _BOOTSTRAPPED = True
+        return []
+
+    loaded: List[Path] = []
+    for env_path in dotenv_search_paths():
+        if env_path.is_file():
+            load_dotenv(env_path, override=False)
+            loaded.append(env_path)
+            break
+
+    _BOOTSTRAPPED = True
+    return loaded

--- a/rooms/settings.py
+++ b/rooms/settings.py
@@ -11,6 +11,7 @@ import yaml
 from pydantic import BaseModel, Field, ValidationError
 
 from .config import AgentConfig
+from .env import bootstrap_environment
 
 # Shipped persona definitions (single source for reset / use_shipped_personas)
 SHIPPED_PERSONAS: List[dict] = [
@@ -139,6 +140,7 @@ def _apply_ollama_env(settings: RoomsSettings) -> None:
 
 def load_settings(explicit_path: Optional[str] = None, *, required: bool = False) -> RoomsSettings:
     """Load settings from the first matching file, or return built-in defaults."""
+    bootstrap_environment()
     path = find_settings_file(explicit_path)
     if path is None:
         if required and explicit_path:

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,54 @@
+import os
+
+from rooms.env import bootstrap_environment, dotenv_search_paths
+
+
+def test_dotenv_search_paths_prefers_cwd_before_repo_root(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    work = repo / "work"
+    work.mkdir(parents=True)
+    monkeypatch.chdir(work)
+    monkeypatch.setattr("rooms.env.repo_root", lambda: repo)
+
+    paths = dotenv_search_paths()
+    assert paths[0] == (work / ".env").resolve()
+    assert paths[1] == (repo / ".env").resolve()
+
+
+def test_bootstrap_environment_loads_env_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("ROOMS_TEST_ENV_KEY=bootstrap-value\n", encoding="utf-8")
+    os.environ.pop("ROOMS_TEST_ENV_KEY", None)
+
+    loaded = bootstrap_environment(force=True)
+    assert loaded == [(tmp_path / ".env").resolve()]
+    assert os.environ["ROOMS_TEST_ENV_KEY"] == "bootstrap-value"
+
+    os.environ.pop("ROOMS_TEST_ENV_KEY", None)
+
+
+def test_bootstrap_environment_does_not_override_existing_env(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("ROOMS_TEST_ENV_KEY=from-dotenv\n", encoding="utf-8")
+    os.environ["ROOMS_TEST_ENV_KEY"] = "from-shell"
+
+    bootstrap_environment(force=True)
+    assert os.environ["ROOMS_TEST_ENV_KEY"] == "from-shell"
+
+    os.environ.pop("ROOMS_TEST_ENV_KEY", None)
+
+
+def test_load_settings_bootstraps_env(tmp_path, monkeypatch):
+    import rooms.env as env_module
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / ".env").write_text("ROOMS_TEST_SETTINGS_ENV=loaded\n", encoding="utf-8")
+    os.environ.pop("ROOMS_TEST_SETTINGS_ENV", None)
+    env_module._BOOTSTRAPPED = False
+
+    from rooms.settings import load_settings
+
+    load_settings()
+    assert os.environ["ROOMS_TEST_SETTINGS_ENV"] == "loaded"
+
+    os.environ.pop("ROOMS_TEST_SETTINGS_ENV", None)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -97,7 +97,8 @@ def test_example_settings_file_exists():
     assert (repo_root() / "rooms.settings.example.yaml").is_file()
 
 
-def test_explicit_config_required_missing(tmp_path):
+def test_explicit_config_required_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
     missing = tmp_path / "nope.yaml"
     with pytest.raises(SettingsError):
         load_settings(str(missing), required=True)


### PR DESCRIPTION
Load optional .env files centrally for CLI and settings bootstrap with shell env precedence, document credential vs YAML config separation, and add skillware plus python-dotenv to core dependencies.